### PR TITLE
Prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased]
 
+## [1.0.0] - 2025-11-26
+
 ### Added
+
 - YARD documentation comments for all public APIs
 - Application template that sets up a new Rails application with sensible defaults
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    staples (0.1.0)
+    staples (1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/staples/version.rb
+++ b/lib/staples/version.rb
@@ -3,5 +3,5 @@
 # The Staples module provides a CLI tool for generating opinionated Rails applications.
 module Staples
   # The current version of the Staples gem.
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Since each release is a breaking change, we bump to `1.0.0`.
